### PR TITLE
Initial Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+/LocalConfig/

--- a/Settings.ini
+++ b/Settings.ini
@@ -1,0 +1,6 @@
+[DEFAULT]
+
+[CREDENTIALS]
+AbuseIPDB_API_Key =
+UBNT_Username =
+UBNT_Password =

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -113,7 +113,10 @@ class NginxErrorLogReader(LogReader):
 
     def print_log_to_console(self, parsed_results):
         for result in parsed_results:
-            print(f'{result['date']} {result['time']} {result['client_ip']}')
+            if result['client_ip'] in self.known_ips.values():
+                print(f'{result['date']} {result['time']} {result['client_ip']} FRIENDLY')
+            else:
+                print(f'{result['date']} {result['time']} {result['client_ip']}')
 
 
 

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -26,7 +26,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 UBNT_LOGIN_URL = 'https://192.168.1.4:8443/api/login'
 UBNT_LOGOUT_URL = 'https://192.168.1.4:8443/api/logout'
-UBNT_FW_GROUP_URL = 'https://192.168.1.4:8443/api/s/566dua2v/rest/firewallgroup/673e8652f46fb86a9ec297fd'
+UBNT_FW_GROUP_URL = 'https://192.168.1.4:8443/api/s/566dua2v/rest/firewallgroup/673ed5dbf46fb86a9ec2c34a'
 
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 FORMATTER = logging.Formatter('[%(asctime)s][%(levelname)s]: %(message)s', DATE_FORMAT)
@@ -527,12 +527,16 @@ class NginxErrorLogReader(LogReader):
 
     def _create_ban_list(self):
         self.ban_list = []
+        self.ban_list_ips = []
         for result in self.parsed_results:
             ip = result['ClientIP']
             if ip not in [entry['ClientIP'] for entry in self.ban_list]:
                 ip_count = sum(1 for entry in self.parsed_results if entry.get('ClientIP') == ip)
                 result['Count'] = ip_count
                 self.ban_list.append(result)
+
+        for entry in self.ban_list:
+            self.ban_list_ips.append(entry['ClientIP'])
 
     def add_abuseipdb_for_ban_list(self):
         # Add info from AbuseIPDB to abuse_ip_db table in SQLite
@@ -620,21 +624,21 @@ def main():
     # Update list of Blacklisted IPs
     # readit.load_current_blacklist()
 
-    # Read nginx error log and spit out csv
-    readit.parse_log_file()
-
     new_list = [
-        "45.129.14.71",
-        "118.179.203.50",
-        "156.220.208.167",
-        "135.125.216.246",
-        "198.235.24.202",
-        "81.161.238.40"
+        "138.197.27.249",
+        "66.240.236.116",
+        "4.151.230.245",
+        "70.39.75.151"
     ]
 
-    readit.set_ubnt_blacklist(new_list)
-    # readit.write_ban_list_csv()
-    # readit.write_parsed_results_csv()
+
+    # Read nginx error log and spit out csv
+    readit.parse_log_file()
+    #readit.set_ubnt_blacklist(new_list)
+
+    readit.write_ban_list_csv()
+    #readit.write_parsed_results_csv()
+    #readit.set_ubnt_blacklist(readit.ban_list)
     # readit.add_abuseipdb_for_ban_list()
 
     # readit.print_log_to_console()

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import logging
 import sys
@@ -7,6 +8,7 @@ from pyparsing import Word, nums, alphas, alphanums, Suppress, quotedString, Gro
 
 NGINX_ERROR_LOG = r'LocalConfig/error.log'
 KNOWN_IPS_LIST = r'LocalConfig/known_ips.json'
+CSV_PATH = r'LocalConfig/'
 
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 FORMATTER = logging.Formatter('[%(asctime)s][%(levelname)s]: %(message)s', DATE_FORMAT)
@@ -31,6 +33,20 @@ class LogReader(object):
         with open(KNOWN_IPS_LIST, 'r') as file:
             data = json.load(file)
             return data
+
+    def _write_csv(self, list_of_dicts, file_path):
+        with open(file_path, mode='w', newline='') as file:
+            # Define the fieldnames (this will be the header row in the CSV)
+            fieldnames = list_of_dicts[0].keys()
+
+            # Create a DictWriter object
+            writer = csv.DictWriter(file, fieldnames=fieldnames)
+
+            # Write the header row
+            writer.writeheader()
+
+            # Write data rows
+            writer.writerows(list_of_dicts)
 
     def write_known_ips(self):
         data = self.known_ips

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -64,7 +64,8 @@ class NginxErrorLogReader(LogReader):
                             self.ip_address +
                             Optional(Suppress("]")))
         self.client_expr.setParseAction(lambda t: t[0])
-        self.modsecurity_msg = Literal("ModSecurity: Access denied with code") + self.integer
+        self.http_code = Literal("ModSecurity: Access denied with code") + self.integer
+        self.http_code.setParseAction(lambda t: t[1])
 
         # Define the full line structure
         self.log_line = (
@@ -73,7 +74,7 @@ class NginxErrorLogReader(LogReader):
             self.process_ids("process_ids") +
             self.request_id("request_id") +
             self.client_expr("client_ip") +
-            self.modsecurity_msg +
+            self.http_code("http_code") +
             Optional(Regex(".*"))  # Capture the remaining part of the message if needed
         )
 
@@ -139,6 +140,7 @@ def main():
     # print(log_results[0]['datetime'])
     # print(log_results[0]['date'])
     # print(log_results[0]['time'])
+    print(log_results[0]['http_code'])
 
 if __name__ == '__main__':
     main()

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -3,7 +3,9 @@ import csv
 import json
 import logging
 import requests
+import sqlite3
 import sys
+
 
 from pyparsing import Word, nums, alphanums, Suppress, quotedString, Group, Combine, Regex, Optional, Literal, \
     removeQuotes, SkipTo, ParseResults
@@ -12,6 +14,7 @@ CONFIG_PATH = r'LocalConfig/Settings.ini'
 NGINX_ERROR_LOG = r'LocalConfig/error.log.1'
 KNOWN_IPS_LIST = r'LocalConfig/known_ips.json'
 CSV_PATH = r'LocalConfig/'
+SQLite_DB = 'nginx_punk_buster.db'
 
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 FORMATTER = logging.Formatter('[%(asctime)s][%(levelname)s]: %(message)s', DATE_FORMAT)
@@ -83,6 +86,11 @@ class LogReader(object):
             return response.json()
         else:
             return {"error": f"Request failed with status code {response.status_code}", "details": response.text}
+
+    def create_sqlite_connection(self, db_name=SQLite_DB):
+        conn = sqlite3.connect(db_name)
+        return conn
+
 
 
 

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -2,6 +2,7 @@ import configparser
 import csv
 import json
 import logging
+import requests
 import sys
 
 from pyparsing import Word, nums, alphanums, Suppress, quotedString, Group, Combine, Regex, Optional, Literal, \
@@ -65,6 +66,24 @@ class LogReader(object):
         data = self.known_ips
         with open(KNOWN_IPS_LIST, 'w') as file:
             json.dump(data, file, indent=4)
+
+    def abuse_ipdb_check_ip(self, ip_address):
+        url = f'https://api.abuseipdb.com/api/v2/check'
+        headers = {
+            "Key": ABUSEIPDB_API_KEY,
+            "Accept": "application/json"
+        }
+        params = {
+            "ipAddress": ip_address,
+            "maxAgeInDays": 90,
+            "verbose": True
+        }
+        response = requests.get(url, headers=headers, params=params)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            return {"error": f"Request failed with status code {response.status_code}", "details": response.text}
+
 
 
 

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -139,6 +139,8 @@ class NginxErrorLogReader(LogReader):
                     # TODO: Save lines that were not parsed for later analysis
                     logger.error(f'Error: {e}')
 
+        self._create_ban_list()
+
 
     def print_log_to_console(self):
         if self.parsed_results is not None:
@@ -154,8 +156,14 @@ class NginxErrorLogReader(LogReader):
     def _remove_known_ips(self):
         pass
 
-    def _de_dupe_logs(self):
-        pass
+    def _create_ban_list(self):
+        self.ban_list = []
+        for result in self.parsed_results:
+            ip = result['ClientIP']
+            if ip not in [entry['ClientIP'] for entry in self.ban_list]:
+                ip_count = sum(1 for entry in self.parsed_results if entry.get('ClientIP') == ip)
+                result['Count'] = ip_count
+                self.ban_list.append(result)
 
 
 

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -98,17 +98,27 @@ class NginxErrorLogReader(LogReader):
         with open(self.log_location, 'r') as file:
             for line in file:
                 try:
+                    logger.debug(f'Attempting to parse nginx error log: {line}')
                     parsed = self.log_line.parseString(line)
-                    parsed['datetime'] = f'{parsed['date']} {parsed['time']}'
-                    logger.debug(f'Parsed line: {parsed}')
-                    logger.debug(f'Client IP: {parsed["client_ip"]}')
-                    logger.debug(f'Datetime: {parsed["datetime"]}')
                     if parsed['client_ip'] not in self.known_ips.values():
-                        parsed_results.append(parsed)
+                        parsed['datetime'] = f'{parsed['date']} {parsed['time']}'
+                        parsed_dict = {
+                            'Datetime': parsed['datetime'],
+                            'ClientIP': parsed['client_ip'],
+                            'HTTP_Code': parsed['http_code'],
+                            'Severity': parsed['fields']['severity'],
+                            'Message': parsed['fields']['msg'],
+                            'URI': parsed['fields']['uri']
+                        }
+                        parsed_results.append(parsed_dict)
+                        logger.debug(f'Parsed line: {parsed}')
+
 
                 except Exception as e:
                     logger.error(f'Failed to parse line: {line}')
+                    # TODO: Save lines that were not parsed for later analysis
                     logger.error(f'Error: {e}')
+
 
         return parsed_results
 

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -654,22 +654,36 @@ def main():
     # readit.load_current_blacklist()
 
     new_list = [
-        "138.197.27.249",
-        "66.240.236.116",
-        "4.151.230.245",
-        "70.39.75.151"
+        '192.189.2.218',
+        '20.118.68.251',
+        '104.209.34.203',
+        '70.39.75.135',
+        '4.151.229.99',
+        '104.40.75.76',
+        '66.94.114.121',
+        '81.161.238.40',
+        '47.251.103.74',
+        '4.246.246.232',
+        '193.177.182.8',
+        '20.225.3.119',
+        '138.197.27.249',
+        '66.240.236.116',
+        '4.151.230.245',
+        '70.39.75.151'
     ]
 
 
     # Read nginx error log and spit out csv
-    readit.parse_log_file()
+    #readit.parse_log_file()
     #readit.set_ubnt_blacklist(new_list)
 
-    readit.write_ban_list_csv()
+    #readit.write_ban_list_csv()
     #readit.write_parsed_results_csv()
-    readit.set_ubnt_blacklist(readit.ban_list_ips)
-    readit.insert_into_blacklist(readit.ban_list_ips)
-    readit.add_abuseipdb_for_ban_list()
+    #readit.set_ubnt_blacklist(readit.ban_list_ips)
+    #readit.insert_into_blacklist(readit.ban_list_ips)
+    #readit.add_abuseipdb_for_ban_list()
+
+    # readit.insert_into_blacklist(new_list)
 
     # readit.print_log_to_console()
     # readit.write_known_ips()

--- a/nginx_punk_buster.py
+++ b/nginx_punk_buster.py
@@ -1,0 +1,72 @@
+import json
+from pyparsing import Word, nums, alphas, alphanums, Suppress, quotedString, Group, Combine, OneOrMore, delimitedList, \
+    ParseException, Regex, Optional
+
+NGINX_ERROR_LOG = r'/LocalConfig/error.log'
+KNOWN_IPS_LIST = r'LocalConfig/known_ips.json'
+
+
+
+class LogReader(object):
+    def __init__(self):
+        self.known_ips = self._get_known_ips()
+
+
+    def _get_known_ips(self):
+        with open(KNOWN_IPS_LIST, 'r') as file:
+            data = json.loads(file)
+            return data
+
+    def write_known_ips(self):
+        data = self.known_ips
+        with open(KNOWN_IPS_LIST, 'w') as file:
+            json.dump(data, file, indent=4)
+
+
+
+
+# Define basic components
+integer = Word(nums)
+ip_address = Combine(Word(nums) + ('.' + Word(nums)) * 3)
+datetime_part = Word(nums, exact=4) + '/' + Word(nums, exact=2) + '/' + Word(nums, exact=2)
+time_part = Word(nums, exact=2) + ':' + Word(nums, exact=2) + ':' + Word(nums, exact=2)
+
+# Define the new pattern for process ID and request ID
+process_ids = Combine(integer + '#' + integer)
+request_id = Suppress(':') + Suppress('*') + integer
+
+# Define other parts of the log line
+datetime_expr = datetime_part + time_part
+error_level = Literal("[error]")
+client_expr = Suppress("[client") + ip_address + Suppress("]")
+modsecurity_msg = Literal("ModSecurity: Access denied with code") + integer
+
+# Define the full line structure
+log_line = (
+    datetime_expr("datetime") +
+    error_level("level") +
+    process_ids("process_ids") +
+    request_id("request_id") +
+    client_expr("client_ip") +
+    modsecurity_msg +
+    Optional(Regex(".*"))  # Capture the remaining part of the message if needed
+)
+
+# Function to parse each line of the log file
+def parse_log_file(file_path):
+    with open(file_path, 'r') as file:
+        for line in file:
+            try:
+                parsed = log_line.parseString(line)
+                print("Parsed line:", parsed)
+            except Exception as e:
+                print("Failed to parse line:", line)
+                print("Error:", e)
+
+
+# Usage
+readit = LogReader()
+readit.write_known_ips()
+log_file_path = NGINX_ERROR_LOG
+parse_log_file(log_file_path)
+


### PR DESCRIPTION
- Parses most errors in nginx error.log written by ModSecurity
- Makes a list of those parsed errors and deduplicates it
- Takes the deduplicated list and can add to a Firewall IP Group in Ubiquiti Network Controller to be used as a blacklist
- Uses AbuseIPDB API to check IPs in the blacklist for their abuse score
- Blacklisted IPs and AbuseIPDB data are stored in a SQLite DB
- Externalized list for known IP Addresses to exclude from blacklist
- Credentials for APIs are stored in an external Settings.ini file
- Built foundation for a factory pattern to allow for ingesting different logs